### PR TITLE
Fix Android backup-import NotFoundError

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "dev",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,5 @@ Dead code checks are **blocking**. Remove dead code rather than adding exception
 ## Workflow
 
 When developing new features or making changes in this repo, use test-driven development. Write tests first covering different cases, ensure they fail, then make edits until they are all green. Commit your changes when tests pass.
+
+The codebase should be optimized for claude context. This means keeping files slim and follow the single-responsibility principle. Whenever you edit a file that is large and should be refactored, suggest to the user to make that refactor since you have the context in memory anyways.

--- a/src/components/settings/BackupRestoreSection.tsx
+++ b/src/components/settings/BackupRestoreSection.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import {
   buildBackupData,
   downloadBackupFile,
-  validateBackupData,
+  parseBackupFile,
   restoreBackupData,
   recordBackupExported,
 } from '../../lib/backup-restore';
@@ -40,12 +40,7 @@ export default function BackupRestoreSection() {
     try {
       setIsImporting(true);
 
-      const text = await file.text();
-      const importData = JSON.parse(text);
-
-      if (!validateBackupData(importData)) {
-        throw new Error('This file is not a valid fitness tracker backup');
-      }
+      const importData = await parseBackupFile(file);
 
       // Confirm before restoring
       if (

--- a/src/lib/backup-restore.test.ts
+++ b/src/lib/backup-restore.test.ts
@@ -10,6 +10,7 @@ import {
   recordBackupExported,
   getLastBackupDate,
   isBackupReminderDue,
+  parseBackupFile,
   BackupData,
 } from './backup-restore';
 
@@ -192,6 +193,37 @@ describe('backup-restore', () => {
 
       const fifteenDaysLater = exportedAt + 15 * 24 * 60 * 60 * 1000;
       expect(isBackupReminderDue(fifteenDaysLater)).toBe(true);
+    });
+  });
+
+  describe('parseBackupFile', () => {
+    it('reads, parses, and validates a well-formed backup file', async () => {
+      const data: BackupData = {
+        version: '1.1',
+        exportDate: 1,
+        userProfile: PROFILE,
+        workouts: [WORKOUT],
+        history: [HISTORY_ENTRY],
+      };
+      const file = new File([JSON.stringify(data)], 'backup.json', { type: 'application/json' });
+
+      const parsed = await parseBackupFile(file);
+
+      expect(parsed).toEqual(data);
+    });
+
+    it('rejects a file that is not valid JSON', async () => {
+      const file = new File(['not json'], 'backup.json', { type: 'application/json' });
+
+      await expect(parseBackupFile(file)).rejects.toThrow('not valid JSON');
+    });
+
+    it('rejects valid JSON that is not a valid backup shape', async () => {
+      const file = new File([JSON.stringify({ foo: 'bar' })], 'backup.json', {
+        type: 'application/json',
+      });
+
+      await expect(parseBackupFile(file)).rejects.toThrow('not a valid fitness tracker backup');
     });
   });
 });

--- a/src/lib/backup-restore.ts
+++ b/src/lib/backup-restore.ts
@@ -46,6 +46,39 @@ export async function buildBackupData(): Promise<BackupData> {
   };
 }
 
+/**
+ * Reads a File as text via FileReader rather than the modern Blob.text()/arrayBuffer()
+ * promise APIs. Android Chrome has a known bug where reading files picked from certain
+ * content providers (e.g. the Downloads folder) via those newer APIs throws a NotFoundError
+ * ("a requested file or directory could not be found") — FileReader doesn't hit it.
+ */
+export function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error ?? new Error('Could not read the selected file'));
+    reader.readAsText(file);
+  });
+}
+
+/** Reads, parses, and validates a picked backup file, throwing a specific message at each stage. */
+export async function parseBackupFile(file: File): Promise<BackupData> {
+  const text = await readFileAsText(file);
+
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error('This file is not valid JSON');
+  }
+
+  if (!validateBackupData(data)) {
+    throw new Error('This file is not a valid fitness tracker backup');
+  }
+
+  return data;
+}
+
 export function validateBackupData(data: unknown): data is BackupData {
   if (!data || typeof data !== 'object') return false;
   const candidate = data as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Fix the `NotFoundError` ("a requested file or directory could not be found") users hit when importing a backup file picked from Android's Downloads folder — `file.text()` has a known Chromium/Android bug with certain content providers; switched to `FileReader`, which doesn't hit it.
- Extracted read+parse+validate into a single tested `parseBackupFile()` helper with distinct error messages per failure stage (unreadable file / invalid JSON / invalid backup shape).
- Minor: `.claude/launch.json` now allows falling back to another port if 5173 is busy.
- Includes a small pending `Update CLAUDE.md` commit already on dev.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (386 tests) all pass
- [x] Dead-code / dead-component scans clean
- [x] New unit tests confirm `parseBackupFile` correctly parses a valid backup and rejects invalid JSON / invalid backup shape (via jsdom's `FileReader`)
- [ ] User to re-test import from their Android phone's Downloads folder after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)