### PR TITLE
Backup import: PWA update fix + paste-JSON fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ Dead code checks are **blocking**. Remove dead code rather than adding exception
 
 ## Workflow
 
-When developing new features or making changes in this repo, use test-driven development. Write tests first covering different cases, ensure they fail, then make edits until they are all green. Commit your changes when tests pass.
+When developing new features or making changes in this repo, use test-driven development. Write tests first covering different cases, ensure they fail, then make edits until they are all green.
+
+Commit and push your changes when tests pass to the dev branch. Dont push to merge to main before I give consent.
 
 The codebase should be optimized for claude context. This means keeping files slim and follow the single-responsibility principle. Whenever you edit a file that is large and should be refactored, suggest to the user to make that refactor since you have the context in memory anyways.

--- a/src/components/settings/BackupRestoreSection.tsx
+++ b/src/components/settings/BackupRestoreSection.tsx
@@ -3,8 +3,10 @@ import {
   buildBackupData,
   downloadBackupFile,
   parseBackupFile,
+  parseBackupJSON,
   restoreBackupData,
   recordBackupExported,
+  BackupData,
 } from '../../lib/backup-restore';
 import Button from '../common/Button';
 
@@ -15,6 +17,8 @@ import Button from '../common/Button';
 export default function BackupRestoreSection() {
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
+  const [showPasteImport, setShowPasteImport] = useState(false);
+  const [pastedJSON, setPastedJSON] = useState('');
 
   const handleExportData = async () => {
     try {
@@ -33,31 +37,32 @@ export default function BackupRestoreSection() {
     }
   };
 
+  // Shared by both the file-picker and paste-JSON import paths.
+  const confirmAndRestore = async (importData: BackupData) => {
+    if (
+      !confirm(
+        'This will replace all your current data with the backup. Are you sure you want to continue?'
+      )
+    ) {
+      return;
+    }
+
+    await restoreBackupData(importData);
+
+    alert('Data restored successfully! Reloading the app...');
+    // Full reload (rather than just navigating) so every Zustand store re-initializes
+    // from the freshly-restored data instead of keeping whatever it had cached in memory.
+    window.location.href = '/';
+  };
+
   const handleImportData = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
 
     try {
       setIsImporting(true);
-
       const importData = await parseBackupFile(file);
-
-      // Confirm before restoring
-      if (
-        !confirm(
-          'This will replace all your current data with the backup. Are you sure you want to continue?'
-        )
-      ) {
-        setIsImporting(false);
-        return;
-      }
-
-      await restoreBackupData(importData);
-
-      alert('Data restored successfully! Reloading the app...');
-      // Full reload (rather than just navigating) so every Zustand store re-initializes
-      // from the freshly-restored data instead of keeping whatever it had cached in memory.
-      window.location.href = '/';
+      await confirmAndRestore(importData);
     } catch (error) {
       console.error('Import failed:', error);
       const message = error instanceof Error ? error.message : 'Unknown error';
@@ -66,6 +71,20 @@ export default function BackupRestoreSection() {
       setIsImporting(false);
       // Reset file input
       event.target.value = '';
+    }
+  };
+
+  const handlePasteImport = async () => {
+    try {
+      setIsImporting(true);
+      const importData = parseBackupJSON(pastedJSON);
+      await confirmAndRestore(importData);
+    } catch (error) {
+      console.error('Import failed:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      alert(`Failed to import data: ${message}`);
+    } finally {
+      setIsImporting(false);
     }
   };
 
@@ -102,6 +121,40 @@ export default function BackupRestoreSection() {
             </div>
           </label>
         </div>
+
+        <button
+          type="button"
+          onClick={() => setShowPasteImport((prev) => !prev)}
+          className="w-full text-xs text-text-muted hover:text-text underline"
+        >
+          {showPasteImport ? 'Hide paste option' : "Import not working? Paste backup JSON instead"}
+        </button>
+
+        {showPasteImport && (
+          <div className="space-y-2">
+            <p className="text-xs text-text-muted">
+              Some Android browsers can't read files picked from the file browser. As a
+              workaround, open the backup file in a text/notes app, copy all of its contents,
+              and paste them below.
+            </p>
+            <textarea
+              value={pastedJSON}
+              onChange={(e) => setPastedJSON(e.target.value)}
+              disabled={isImporting}
+              rows={6}
+              placeholder='{"version": "1.1", ...}'
+              className="w-full px-3 py-2 bg-background border border-background-lighter text-text rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent outline-none placeholder:text-text-muted text-xs font-mono"
+            />
+            <Button
+              onClick={handlePasteImport}
+              fullWidth
+              variant="secondary"
+              disabled={isImporting || !pastedJSON.trim()}
+            >
+              {isImporting ? 'Importing...' : 'Restore From Pasted JSON'}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/settings/BackupRestoreSection.tsx
+++ b/src/components/settings/BackupRestoreSection.tsx
@@ -103,7 +103,9 @@ export default function BackupRestoreSection() {
         <div>
           <input
             type="file"
-            accept=".json"
+            // Deliberately unfiltered: some Android file pickers route MIME/extension-filtered
+            // requests through a flakier document provider than an unfiltered pick. The file
+            // content itself is still validated after reading, so this is safe either way.
             onChange={handleImportData}
             disabled={isImporting}
             className="hidden"

--- a/src/lib/backup-restore.test.ts
+++ b/src/lib/backup-restore.test.ts
@@ -11,6 +11,7 @@ import {
   getLastBackupDate,
   isBackupReminderDue,
   parseBackupFile,
+  parseBackupJSON,
   BackupData,
 } from './backup-restore';
 
@@ -224,6 +225,30 @@ describe('backup-restore', () => {
       });
 
       await expect(parseBackupFile(file)).rejects.toThrow('not a valid fitness tracker backup');
+    });
+  });
+
+  describe('parseBackupJSON', () => {
+    it('parses and validates a well-formed backup string (the paste-JSON fallback path)', () => {
+      const data: BackupData = {
+        version: '1.1',
+        exportDate: 1,
+        userProfile: PROFILE,
+        workouts: [WORKOUT],
+        history: [HISTORY_ENTRY],
+      };
+
+      expect(parseBackupJSON(JSON.stringify(data))).toEqual(data);
+    });
+
+    it('rejects text that is not valid JSON', () => {
+      expect(() => parseBackupJSON('not json')).toThrow('not valid JSON');
+    });
+
+    it('rejects valid JSON that is not a valid backup shape', () => {
+      expect(() => parseBackupJSON(JSON.stringify({ foo: 'bar' }))).toThrow(
+        'not a valid fitness tracker backup'
+      );
     });
   });
 });

--- a/src/lib/backup-restore.ts
+++ b/src/lib/backup-restore.ts
@@ -47,10 +47,12 @@ export async function buildBackupData(): Promise<BackupData> {
 }
 
 /**
- * Reads a File as text via FileReader rather than the modern Blob.text()/arrayBuffer()
- * promise APIs. Android Chrome has a known bug where reading files picked from certain
- * content providers (e.g. the Downloads folder) via those newer APIs throws a NotFoundError
- * ("a requested file or directory could not be found") — FileReader doesn't hit it.
+ * Reads a File as text via FileReader. Some Android/Chrome + content-provider
+ * combinations can fail to hand back readable bytes for a picked file at all
+ * (a NotFoundError — "a requested file or directory could not be found" — from
+ * any read API, not specific to FileReader vs. Blob.text()). When that happens,
+ * `parsePastedBackupJSON` below is the fallback: paste the file's contents in
+ * directly instead of relying on the file picker to read them.
  */
 export function readFileAsText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -61,22 +63,26 @@ export function readFileAsText(file: File): Promise<string> {
   });
 }
 
-/** Reads, parses, and validates a picked backup file, throwing a specific message at each stage. */
-export async function parseBackupFile(file: File): Promise<BackupData> {
-  const text = await readFileAsText(file);
-
+/** Parses and validates backup JSON text, throwing a specific message at each stage. */
+export function parseBackupJSON(text: string): BackupData {
   let data: unknown;
   try {
     data = JSON.parse(text);
   } catch {
-    throw new Error('This file is not valid JSON');
+    throw new Error('This is not valid JSON');
   }
 
   if (!validateBackupData(data)) {
-    throw new Error('This file is not a valid fitness tracker backup');
+    throw new Error('This is not a valid fitness tracker backup');
   }
 
   return data;
+}
+
+/** Reads, parses, and validates a picked backup file, throwing a specific message at each stage. */
+export async function parseBackupFile(file: File): Promise<BackupData> {
+  const text = await readFileAsText(file);
+  return parseBackupJSON(text);
 }
 
 export function validateBackupData(data: unknown): data is BackupData {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,27 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { registerSW } from 'virtual:pwa-register'
 import App from './App.tsx'
 import './index.css'
 import { initPWAMode } from './utils/pwaHelper'
 
 // Initialize PWA mode detection
 initPWAMode();
+
+// The default auto-injected registration script only registers the service
+// worker once and never actively checks for a newer one, so a phone that
+// already has the app open/installed can keep running a stale bundle for a
+// long time. `immediate: true` forces an update check right away, and
+// activating a new SW (registerType: 'autoUpdate') reloads the page for it.
+registerSW({
+  immediate: true,
+  onRegisteredSW(_swUrl, registration) {
+    if (!registration) return;
+    setInterval(() => {
+      registration.update();
+    }, 60 * 60 * 1000); // hourly, in case the app is left open for a long time
+  },
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
 
 interface ImportMetaEnv {
   readonly MODE: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'autoUpdate',
+      // Registered manually in main.tsx via virtual:pwa-register so we can force
+      // an immediate update check + reload — the auto-injected script only
+      // registers the SW once and never actively checks for a newer one.
+      injectRegister: false,
       includeAssets: ['favicon.ico', 'favicon-16x16.png', 'favicon-32x32.png'],
       manifest: {
         name: 'Home Fitness Tracker',


### PR DESCRIPTION
## Summary
- Force active PWA update checks (`virtual:pwa-register` + `immediate: true`) so future deploys actually reach devices that already have the app installed/open, instead of relying on the passive default registration script.
- Add a "paste backup JSON directly" fallback in Backup & Restore, for the case where the Android file picker can't hand back readable file bytes (reproduced consistently on a Samsung A22 5G — same NotFoundError across fresh exports, old files, after a full storage wipe, and across retries).
- Drop the `.json` file-type filter on the import `<input type="file">` — some Android pickers route filtered requests through a flakier document provider; content is validated after reading regardless.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (389 tests), dead-code/dead-component scans all clean
- [x] `npm run build` succeeds
- [ ] User to retry import on their Samsung A22 5G (file picker with no type filter, or the new paste-JSON option) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)